### PR TITLE
F17, F22 Implentation

### DIFF
--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml
@@ -1886,7 +1886,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: saad1038/ts-voucher-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: saad1038/ts-cancel-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml
@@ -570,7 +570,7 @@ spec:
     spec:
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: saad1038/ts-contacts-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
@@ -1886,7 +1886,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: saad1038/ts-voucher-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: saad1038/ts-cancel-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
@@ -570,7 +570,7 @@ spec:
     spec:
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: saad1038/ts-contacts-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
@@ -919,7 +919,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: saad1038/ts-contacts-service:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
@@ -3004,7 +3004,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: saad1038/ts-voucher-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
@@ -641,7 +641,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: saad1038/ts-cancel-service:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
@@ -919,7 +919,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: saad1038/ts-contacts-service:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
@@ -3004,7 +3004,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: saad1038/ts-voucher-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
+++ b/deploy-job/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
@@ -641,7 +641,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: saad1038/ts-cancel-service:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent

--- a/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part2.yml
+++ b/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part2.yml
@@ -1456,7 +1456,7 @@ spec:
     spec:
       containers:
       - name: ts-avatar-service
-        image: codewisdom/ts-avatar-service:0.1.0
+        image: codewisdom/ts-avatar-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 17001

--- a/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part2.yml
+++ b/deployment/kubernetes-manifests/k8s-with-istio/ts-deployment-part2.yml
@@ -1456,7 +1456,7 @@ spec:
     spec:
       containers:
       - name: ts-avatar-service
-        image: codewisdom/ts-avatar-service:latest
+        image: codewisdom/ts-avatar-service:0.1.0
         imagePullPolicy: Always
         ports:
         - containerPort: 17001

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
@@ -1886,7 +1886,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: saad1038/ts-voucher-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: saad1038/ts-cancel-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
@@ -570,7 +570,7 @@ spec:
     spec:
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: saad1038/ts-contacts-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
@@ -919,7 +919,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: saad1038/ts-contacts-service:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
@@ -3004,7 +3004,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: saad1038/ts-voucher-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml
@@ -641,7 +641,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: saad1038/ts-cancel-service:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
@@ -919,7 +919,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: saad1038/ts-contacts-service:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
@@ -3004,7 +3004,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: saad1038/ts-voucher-service:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
@@ -641,7 +641,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: saad1038/ts-cancel-service:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.12.RELEASE</version>
+        <version>2.7.18</version>
     </parent>
 
     <modules>
@@ -69,7 +69,33 @@
         <dependency>
             <groupId>com.alibaba.cloud</groupId>
             <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
-            <version>2.2.7.RELEASE</version>
+        </dependency>
+        
+        <!--        Spring Cloud LoadBalancer (replaces Ribbon in 2021.0.x) -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+        </dependency>
+
+        <!--        springdoc-openapi for automatic Swagger UI (all services inherit) -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.15</version>
+        </dependency>
+
+        <!--        OpenFeature SDK for feature flags (all services inherit) -->
+        <dependency>
+            <groupId>dev.openfeature</groupId>
+            <artifactId>sdk</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+
+        <!--        flagd provider for OpenFeature (all services inherit) -->
+        <dependency>
+            <groupId>dev.openfeature.contrib.providers</groupId>
+            <artifactId>flagd</artifactId>
+            <version>0.5.4</version>
         </dependency>
 
         <!--        springboot相关依赖-->
@@ -96,17 +122,7 @@
             <artifactId>lombok</artifactId>
         </dependency>
 
-        <!--        swagger相关依赖-->
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
-            <version>2.4.0</version>
-        </dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.4.0</version>
-        </dependency>
+        <!--        swagger相关依赖 - moved to dependencyManagement with version 3.0.0 -->
 
         <!--        测试相关依赖-->
         <dependency>
@@ -157,16 +173,70 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Hoxton.SR12</version>
+                <version>2021.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.alibaba.cloud</groupId>
                 <artifactId>spring-cloud-alibaba-dependencies</artifactId>
-                <version>2.2.7.RELEASE</version>
+                <version>2021.0.5.0</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Compatible protobuf/gRPC versions for Spring Boot 2.7.x and OpenFeature flagd -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.21.12</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-core</artifactId>
+                <version>1.51.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-protobuf</artifactId>
+                <version>1.51.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty</artifactId>
+                <version>1.51.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-stub</artifactId>
+                <version>1.51.1</version>
+            </dependency>
+            <!-- Force compatible Guava version for gRPC 1.51.1 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.1-jre</version>
+            </dependency>
+            <!-- Upgrade Springfox to be compatible with Guava 31.x -->
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger2</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger-ui</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <!-- Force compatible Netty version for gRPC 1.51.1 -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>4.1.87.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>4.1.87.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/templates/flagd-config.yaml
+++ b/templates/flagd-config.yaml
@@ -12,13 +12,6 @@ data:
           "on": true
           "off": false
         defaultVariant: "off"
-        targeting:
-          if:
-            - var: "enabled"
-            - in:
-              - true
-              - var: "enabled"
-          then: "on"
       
       fault-2-data-request-order-inconsistency:
         state: ENABLED

--- a/templates/flagd-config.yaml
+++ b/templates/flagd-config.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   flags.yaml: |
     flags:
-      fault-1-async-message-order:
+      fault-1-async-message-sequence-control:
         state: ENABLED
         variants:
           "on": true
@@ -20,147 +20,147 @@ data:
               - var: "enabled"
           then: "on"
       
-      fault-2-cpu-occupancy:
+      fault-2-data-request-order-inconsistency:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-3-memory-leak:
+      fault-3-jvm-docker-config-mismatch:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-4-connection-pool-exhaustion:
+      fault-4-ssl-offloading-granularity:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-5-network-partition:
+      fault-5-high-load-timeout-cascade:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-6-disk-space-full:
+      fault-6-sql-error-recursive-requests:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-7-service-unavailable:
+      fault-7-third-party-service-overload:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-8-database-lock-timeout:
+      fault-8-request-key-propagation-failure:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-9-message-queue-overflow:
+      fault-9-css-bidirectional-display-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-10-slow-database-query:
+      fault-10-bom-api-unexpected-output:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-11-configuration-error:
+      fault-11-bom-data-sequence-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-12-authentication-failure:
+      fault-12-price-status-query-chain-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-13-cache-miss-storm:
+      fault-13-price-optimization-order-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-14-http-timeout:
+      fault-14-locked-product-cpi-calculation-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-15-data-inconsistency:
+      fault-15-spark-actor-system-config-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-16-service-discovery-failure:
+      fault-16-spray-max-content-length-limit:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-17-load-balancer-failure:
+      fault-17-nested-sql-select-clause-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-18-session-timeout:
+      fault-18-json-chart-data-null-value:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-19-payment-gateway-error:
+      fault-19-product-price-french-format-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-20-email-service-failure:
+      fault-20-jboss-db2-jar-classpath-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-21-file-upload-failure:
+      fault-21-aria-labeled-accessibility-error:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
       
-      fault-22-monitoring-system-failure:
+      fault-22-sql-column-name-mismatch-error:
         state: ENABLED
         variants:
           "on": true

--- a/templates/flagd-deployment.yaml
+++ b/templates/flagd-deployment.yaml
@@ -46,19 +46,21 @@ spec:
       serviceAccountName: flagd
       containers:
       - name: flagd
-        image: ghcr.io/open-feature/flagd:v0.6.7
+        image: ghcr.io/open-feature/flagd:v0.11.1
         ports:
         - containerPort: 8013
-          name: grpc
+          name: rpc
         - containerPort: 8016
-          name: http
+          name: ofrep
+        - containerPort: 8014
+          name: mgmt
         args:
         - start
         - --uri
         - file:./etc/flagd/flags.yaml
         - --port
         - "8013"
-        - --metrics-port
+        - --ofrep-port
         - "8016"
         - --cors-origin
         - "*"
@@ -72,13 +74,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /readyz
-            port: 8016
+            port: 8014
           initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8016
+            port: 8014
           initialDelaySeconds: 5
           periodSeconds: 5
       volumes:
@@ -97,11 +99,11 @@ spec:
   selector:
     app: flagd
   ports:
-  - name: grpc
+  - name: rpc
     port: 8013
     targetPort: 8013
     protocol: TCP
-  - name: http
+  - name: ofrep
     port: 8016
     targetPort: 8016
     protocol: TCP

--- a/templates/train-ticket-deploy-job.yaml
+++ b/templates/train-ticket-deploy-job.yaml
@@ -11,7 +11,7 @@ spec:
         - name: train-ticket-deploy
           # image: jacksonarthurclark/train-ticket-deploy:latest
           image: saad1038/train-ticket-deploy:latest
-          # TODO: change to IfNotPresent after fault implentations are done
+          # TODO: change to IfNotPresent after fault implementations are done
           # imagePullPolicy: IfNotPresent
           imagePullPolicy: Always
           env:

--- a/templates/train-ticket-deploy-job.yaml
+++ b/templates/train-ticket-deploy-job.yaml
@@ -10,7 +10,7 @@ spec:
       containers:
         - name: train-ticket-deploy
           # image: jacksonarthurclark/train-ticket-deploy:latest
-          image: saad1038/train-ticket-deploy:0.1.0
+          image: saad1038/train-ticket-deploy:0.2.0
           # TODO: change to IfNotPresent after fault implementations are done
           # imagePullPolicy: IfNotPresent
           imagePullPolicy: Always

--- a/templates/train-ticket-deploy-job.yaml
+++ b/templates/train-ticket-deploy-job.yaml
@@ -11,7 +11,9 @@ spec:
         - name: train-ticket-deploy
           # image: jacksonarthurclark/train-ticket-deploy:latest
           image: saad1038/train-ticket-deploy:latest
-          imagePullPolicy: IfNotPresent
+          # TODO: change to IfNotPresent after fault implentations are done
+          # imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: NAMESPACE
               value: "{{ .Values.namespace }}"

--- a/templates/train-ticket-deploy-job.yaml
+++ b/templates/train-ticket-deploy-job.yaml
@@ -9,7 +9,8 @@ spec:
       serviceAccountName: train-ticket-deploy-sa
       containers:
         - name: train-ticket-deploy
-          image: jacksonarthurclark/train-ticket-deploy:latest
+          # image: jacksonarthurclark/train-ticket-deploy:latest
+          image: saad1038/train-ticket-deploy:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/ts-cancel-service/pom.xml
+++ b/ts-cancel-service/pom.xml
@@ -4,83 +4,32 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.services</groupId>
+    <groupId>fdse.microservice</groupId>
     <artifactId>ts-cancel-service</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
-
     <name>ts-cancel-service</name>
-    <description>TrainTicket Cancel Service with F1 Fault Injection</description>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.18</version>
-        <relativePath/>
+        <groupId>org.services</groupId>
+        <artifactId>ts-service</artifactId>
+        <version>0.1.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spring-cloud.version>2021.0.8</spring-cloud.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <groupId>org.services</groupId>
+            <artifactId>ts-common</artifactId>
+            <version>0.1.0</version>
         </dependency>
         
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.33</version>
-            <scope>runtime</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        
-        <!-- OpenFeature SDK for feature flags -->
-        <dependency>
-            <groupId>dev.openfeature</groupId>
-            <artifactId>sdk</artifactId>
-            <version>1.4.0</version>
-        </dependency>
-        
-        <!-- flagd provider for OpenFeature -->
-        <dependency>
-            <groupId>dev.openfeature.contrib.providers</groupId>
-            <artifactId>flagd</artifactId>
-            <version>0.5.4</version>
-        </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>
@@ -90,4 +39,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/ts-cancel-service/src/main/java/cancel/CancelApplication.java
+++ b/ts-cancel-service/src/main/java/cancel/CancelApplication.java
@@ -4,28 +4,50 @@ import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.contrib.providers.flagd.FlagdProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.web.client.RestTemplate;
+// No Swagger imports needed - springdoc works automatically!
 
 import javax.annotation.PostConstruct;
 
+/**
+ * @author fdse
+ */
 @SpringBootApplication
+@EnableAspectJAutoProxy(proxyTargetClass = true)
 @EnableAsync
+@IntegrationComponentScan
+// No Swagger annotations needed - springdoc auto-configures!
+@EnableDiscoveryClient
 public class CancelApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(CancelApplication.class, args);
     }
 
+    @LoadBalanced
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+
     @PostConstruct
     public void initializeFeatureFlags() {
         try {
-            String flagdHost = System.getenv().getOrDefault("FLAGD_HOST", "flagd");
-            int flagdPort = Integer.parseInt(System.getenv().getOrDefault("FLAGD_PORT", "8013"));
-            
-            FlagdProvider provider = new FlagdProvider();
+            // Configure FlagdProvider with explicit settings like Python version - no env vars
+            // Constructor: FlagdProvider(host, port, tls, socketPath)
+            // Note: Java version doesn't have explicit cache disable like Python's CacheType.DISABLED
+            FlagdProvider provider = new FlagdProvider("flagd", 8013, false, null);
+                
             OpenFeatureAPI.getInstance().setProvider(provider);
             
-            System.out.println("[TrainTicket][Cancel][Feature Flags] Connected to flagd at " + flagdHost + ":" + flagdPort);
+            System.out.println("[TrainTicket][Cancel][Feature Flags] Connected to flagd at flagd:8013");
             
         } catch (Exception e) {
             System.err.println("[TrainTicket][Cancel][Feature Flags] Failed to initialize: " + e.getMessage());

--- a/ts-cancel-service/src/main/java/cancel/async/AsyncTask.java
+++ b/ts-cancel-service/src/main/java/cancel/async/AsyncTask.java
@@ -19,7 +19,7 @@ public class AsyncTask {
         
         System.out.println("[TrainTicket][Cancel][AsyncTask] Starting drawback process for order: " + orderId);
         
-        if (featureFlagService.isEnabled("fault-1-async-message-order")) {
+        if (featureFlagService.isEnabled("fault-1-async-message-sequence-control")) {
             System.out.println("[TrainTicket][Cancel][F1 FAULT INJECTED] Adding 8-second delay to payment drawback");
             System.out.println("[TrainTicket][Cancel][F1 FAULT] This will cause async message order violation");
             System.out.println("[TrainTicket][Cancel][F1 FAULT] Order status change may complete before payment drawback");
@@ -47,7 +47,7 @@ public class AsyncTask {
     @Async("mySimpleAsync")
     public Future<Boolean> sendEmail(String email, String orderId) {
         
-        if (featureFlagService.isEnabled("fault-1-async-message-order")) {
+        if (featureFlagService.isEnabled("fault-1-async-message-sequence-control")) {
             System.out.println("[TrainTicket][Cancel][F1 MONITORING] Email notification during F1 fault scenario");
         }
         

--- a/ts-cancel-service/src/main/java/cancel/config/SecurityConfig.java
+++ b/ts-cancel-service/src/main/java/cancel/config/SecurityConfig.java
@@ -6,15 +6,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-
 import static org.springframework.web.cors.CorsConfiguration.ALL;
 
 /**
@@ -23,7 +21,7 @@ import static org.springframework.web.cors.CorsConfiguration.ALL;
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
     /**
      * load password encoder
@@ -45,7 +43,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
      */
     @Bean
     public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurerAdapter() {
+        return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
@@ -59,8 +57,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
 
-    @Override
-    protected void configure(HttpSecurity httpSecurity) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.httpBasic().disable()
                 // close default csrf
                 .csrf().disable()
@@ -68,8 +66,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
+                .antMatchers("/api/v1/cancelservice/test/**").permitAll()  // Allow testing endpoints without auth
                 .antMatchers("/api/v1/cancelservice/**").hasAnyRole("ADMIN", "USER")
-                .antMatchers("/swagger-ui.html", "/webjars/**", "/images/**",
+                .antMatchers("/swagger-ui/**", "/v3/api-docs/**", "/webjars/**", "/images/**",
                         "/configuration/**", "/swagger-resources/**", "/v2/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
@@ -77,5 +76,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         // close cache
         httpSecurity.headers().cacheControl();
+        
+        return httpSecurity.build();
     }
 }

--- a/ts-cancel-service/src/main/java/cancel/controller/CancelController.java
+++ b/ts-cancel-service/src/main/java/cancel/controller/CancelController.java
@@ -1,6 +1,7 @@
 package cancel.controller;
 
 import cancel.service.CancelService;
+import cancel.service.FeatureFlagService;
 import edu.fudan.common.util.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +22,9 @@ public class CancelController {
 
     @Autowired
     CancelService cancelService;
+
+    @Autowired
+    FeatureFlagService featureFlagService;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CancelController.class);
 
@@ -48,6 +52,43 @@ public class CancelController {
         } catch (Exception e) {
             CancelController.LOGGER.error(e.getMessage());
             return ok(new Response<>(1, "error", null));
+        }
+    }
+
+    /**
+     * Testing endpoint to check feature flag values
+     * Usage: GET /api/v1/cancelservice/test/flag/{flagName}
+     * Example: GET /api/v1/cancelservice/test/flag/fault-1-async-message-sequence-control
+     */
+    @CrossOrigin(origins = "*")
+    @GetMapping(path = "/test/flag/{flagName}")
+    public HttpEntity testFlag(@PathVariable String flagName, @RequestHeader HttpHeaders headers) {
+        CancelController.LOGGER.info("[testFlag][Testing Feature Flag][Flag: {}]", flagName);
+        
+        try {
+            boolean flagValue = featureFlagService.isEnabled(flagName);
+            
+            // Create a simple response with flag info
+            String message = String.format("Flag '%s' is %s", flagName, flagValue ? "ENABLED" : "DISABLED");
+            
+            Response<String> response = new Response<>();
+            response.setStatus(1);  // Success
+            response.setMsg(message);
+            response.setData(String.valueOf(flagValue));
+            
+            CancelController.LOGGER.info("[testFlag][Flag Test Result][Flag: {}, Value: {}]", flagName, flagValue);
+            
+            return ok(response);
+            
+        } catch (Exception e) {
+            CancelController.LOGGER.error("[testFlag][Flag Test Error][Flag: {}][Error: {}]", flagName, e.getMessage());
+            
+            Response<String> errorResponse = new Response<>();
+            errorResponse.setStatus(0);  // Error
+            errorResponse.setMsg("Error testing flag: " + e.getMessage());
+            errorResponse.setData("false");
+            
+            return ok(errorResponse);
         }
     }
 

--- a/ts-cancel-service/src/main/resources/application.yml
+++ b/ts-cancel-service/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     nacos:
       discovery:
         server-addr: ${NACOS_ADDRS:nacos-0.nacos-headless.default.svc.cluster.local,nacos-1.nacos-headless.default.svc.cluster.local,nacos-2.nacos-headless.default.svc.cluster.local}
+    loadbalancer:
+      nacos:
+        enabled: true
+      ribbon:
+        enabled: false
   application:
     name: ts-cancel-service
 

--- a/ts-contacts-service/Dockerfile
+++ b/ts-contacts-service/Dockerfile
@@ -1,8 +1,14 @@
-FROM java:8-jre
+FROM openjdk:8-jre-alpine
 
-RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
+# Install timezone data and set Shanghai timezone
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo 'Asia/Shanghai' > /etc/timezone
 
-ADD ./target/ts-contacts-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-contacts-service-1.0.jar"]
+WORKDIR /app
+
+# Copy the JAR file
+COPY target/ts-contacts-service-1.0.jar app.jar
 
 EXPOSE 12347
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/ts-contacts-service/pom.xml
+++ b/ts-contacts-service/pom.xml
@@ -24,10 +24,15 @@
     </properties>
 
     <dependencies>
-        <!--        <dependency>-->
-        <!--            <groupId>org.springframework.boot</groupId>-->
-        <!--            <artifactId>spring-boot-starter-data-mongodb</artifactId>-->
-        <!--        </dependency>-->
+        <!-- Dependencies inherited from parent pom.xml:
+             - spring-cloud-starter-alibaba-nacos-discovery
+             - spring-cloud-starter-loadbalancer
+             - dev.openfeature:sdk
+             - dev.openfeature.contrib.providers:flagd
+             - springdoc-openapi-ui
+        -->
+        
+        <!-- JPA and Database Dependencies (REQUIRED for entity classes and repositories) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -35,7 +40,11 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.33</version>
+            <scope>runtime</scope>
         </dependency>
+        
+        <!-- Common utilities -->
         <dependency>
             <groupId>org.services</groupId>
             <artifactId>ts-common</artifactId>

--- a/ts-contacts-service/src/main/java/contacts/ContactsApplication.java
+++ b/ts-contacts-service/src/main/java/contacts/ContactsApplication.java
@@ -1,5 +1,7 @@
 package contacts;
 
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.contrib.providers.flagd.FlagdProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -10,7 +12,8 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import javax.annotation.PostConstruct;
 
 /**
  * @author fdse
@@ -19,7 +22,6 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 @EnableAsync
 @IntegrationComponentScan
-@EnableSwagger2
 @EnableDiscoveryClient
 public class ContactsApplication {
 
@@ -31,5 +33,21 @@ public class ContactsApplication {
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder.build();
+    }
+
+    // Feature flag initialization
+    @PostConstruct
+    public void initializeFeatureFlags() {
+        try {
+            // Configure FlagdProvider with explicit settings
+            FlagdProvider provider = new FlagdProvider("flagd", 8013, false, null);
+            OpenFeatureAPI.getInstance().setProvider(provider);
+            
+            System.out.println("[TrainTicket][Contacts][Feature Flags] Connected to flagd at flagd:8013");
+            
+        } catch (Exception e) {
+            System.err.println("[TrainTicket][Contacts][Feature Flags] Failed to initialize: " + e.getMessage());
+            e.printStackTrace();
+        }
     }
 }

--- a/ts-contacts-service/src/main/java/contacts/config/SecurityConfig.java
+++ b/ts-contacts-service/src/main/java/contacts/config/SecurityConfig.java
@@ -6,14 +6,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import static org.springframework.web.cors.CorsConfiguration.ALL;
 
@@ -23,7 +22,7 @@ import static org.springframework.web.cors.CorsConfiguration.ALL;
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
     /**
      * load password encoder
@@ -45,7 +44,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
      */
     @Bean
     public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurerAdapter() {
+        return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
@@ -59,17 +58,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
 
-    @Override
-    protected void configure(HttpSecurity httpSecurity) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.httpBasic().disable()
-                // close default csrf
                 .csrf().disable()
-                // close session
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
                 .antMatchers("/api/v1/contactservice/**").hasAnyRole("ADMIN", "USER")
-                .antMatchers("/swagger-ui.html", "/webjars/**", "/images/**",
+                .antMatchers("/swagger-ui/**", "/v3/api-docs/**", "/webjars/**", "/images/**",
                         "/configuration/**", "/swagger-resources/**", "/v2/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
@@ -77,5 +74,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         // close cache
         httpSecurity.headers().cacheControl();
+
+        return httpSecurity.build();
     }
 }

--- a/ts-contacts-service/src/main/java/contacts/repository/ContactsRepository.java
+++ b/ts-contacts-service/src/main/java/contacts/repository/ContactsRepository.java
@@ -46,7 +46,18 @@ public interface ContactsRepository extends CrudRepository<Contacts, String> {
     @Override
     ArrayList<Contacts> findAll();
 
-    @Query(value="SELECT * FROM contacts WHERE account_id = ?1 AND document_number = ?2 AND document_type = ?3", nativeQuery = true)
+    /**
+     * FAULT F22: SQL Column Missing Fault
+     * Changed 'account_id' to 'accountId' to simulate SQL column missing error
+     */
+    @Query(value="SELECT * FROM contacts WHERE accountId = ?1 AND document_number = ?2 AND document_type = ?3", nativeQuery = true)
     Contacts findByAccountIdAndDocumentTypeAndDocumentType(String account_id, String document_number, int document_type);
+
+    /**
+     * CORRECT query method for when fault is disabled
+     * Uses proper column names for normal operation
+     */
+    @Query(value="SELECT * FROM contacts WHERE account_id = ?1 AND document_number = ?2 AND document_type = ?3", nativeQuery = true)
+    Contacts findByAccountIdAndDocumentTypeAndDocumentTypeCorrect(String account_id, String document_number, int document_type);
 
 }

--- a/ts-contacts-service/src/main/java/contacts/service/ContactsServiceImpl.java
+++ b/ts-contacts-service/src/main/java/contacts/service/ContactsServiceImpl.java
@@ -66,7 +66,7 @@ public class ContactsServiceImpl implements ContactsService {
         // FAULT F22: Conditionally execute correct or faulty query based on feature flag
         Contacts c = null;
         try {
-            boolean faultEnabled = featureFlagService.isEnabled("fault-22-sql-column-missing-error");
+            boolean faultEnabled = featureFlagService.isEnabled("fault-22-sql-column-name-mismatch-error");
             
             if (faultEnabled) {
                 LOGGER.info("[TrainTicket][Contacts][F22 ON] Executing FAULTY SQL query with wrong column name");

--- a/ts-contacts-service/src/main/java/contacts/service/FeatureFlagService.java
+++ b/ts-contacts-service/src/main/java/contacts/service/FeatureFlagService.java
@@ -1,0 +1,57 @@
+package contacts.service;
+
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.FlagEvaluationDetails;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+
+@Service
+public class FeatureFlagService {
+    
+    private Client client;
+    
+    @PostConstruct
+    public void initialize() {
+        try {
+            // Get a named client for contacts-service
+            this.client = OpenFeatureAPI.getInstance().getClient("contacts-service");
+            System.out.println("[TrainTicket][Contacts][FeatureFlagService] Initialized successfully");
+        } catch (Exception e) {
+            System.err.println("[TrainTicket][Contacts][FeatureFlagService] Failed to initialize: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+    
+    public boolean isEnabled(String flagName) {
+        try {
+            if (client == null) {
+                System.err.println("[TrainTicket][Contacts][FeatureFlagService] Client not initialized for flag: " + flagName);
+                return false;
+            }
+            
+            // Use getBooleanDetails to get detailed information
+            FlagEvaluationDetails<Boolean> details = client.getBooleanDetails(flagName, false);
+            
+            System.out.println(String.format(
+                "[TrainTicket][Contacts][FeatureFlagService] Flag %s: value=%s, reason=%s", 
+                flagName, 
+                details.getValue(), 
+                details.getReason() != null ? details.getReason() : "N/A"
+            ));
+            
+            // Check for ERROR reason
+            if ("ERROR".equals(details.getReason())) {
+                System.err.println("[TrainTicket][Contacts][FeatureFlagService] Provider error for flag " + flagName);
+                return false;
+            }
+            
+            return Boolean.TRUE.equals(details.getValue());
+            
+        } catch (Exception e) {
+            System.err.println("[TrainTicket][Contacts][FeatureFlagService] Error getting flag " + flagName + ": " + e.getMessage());
+            return false;
+        }
+    }
+}

--- a/ts-contacts-service/src/main/java/contacts/service/FeatureFlagService.java
+++ b/ts-contacts-service/src/main/java/contacts/service/FeatureFlagService.java
@@ -11,6 +11,7 @@ import javax.annotation.PostConstruct;
 public class FeatureFlagService {
     
     private Client client;
+    private boolean isInitialized = false;
     
     @PostConstruct
     public void initialize() {
@@ -18,6 +19,7 @@ public class FeatureFlagService {
             // Get a named client for contacts-service
             this.client = OpenFeatureAPI.getInstance().getClient("contacts-service");
             System.out.println("[TrainTicket][Contacts][FeatureFlagService] Initialized successfully");
+            this.isInitialized = true;
         } catch (Exception e) {
             System.err.println("[TrainTicket][Contacts][FeatureFlagService] Failed to initialize: " + e.getMessage());
             e.printStackTrace();
@@ -25,15 +27,14 @@ public class FeatureFlagService {
     }
     
     public boolean isEnabled(String flagName) {
+        // Simple fix: If not initialized yet, return false (safe default)
+        if (!this.isInitialized || this.client == null) {
+            System.out.println("[TrainTicket][Contacts][FeatureFlagService] Client not ready yet, using safe default (false) for flag: " + flagName);
+            return false;
+        }
+        
         try {
-            if (client == null) {
-                System.err.println("[TrainTicket][Contacts][FeatureFlagService] Client not initialized for flag: " + flagName);
-                return false;
-            }
-            
-            // Use getBooleanDetails to get detailed information
             FlagEvaluationDetails<Boolean> details = client.getBooleanDetails(flagName, false);
-            
             System.out.println(String.format(
                 "[TrainTicket][Contacts][FeatureFlagService] Flag %s: value=%s, reason=%s", 
                 flagName, 

--- a/ts-contacts-service/src/main/resources/application.yml
+++ b/ts-contacts-service/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     nacos:
       discovery:
         server-addr: ${NACOS_ADDRS:nacos-0.nacos-headless.default.svc.cluster.local,nacos-1.nacos-headless.default.svc.cluster.local,nacos-2.nacos-headless.default.svc.cluster.local}
+    loadbalancer:
+      nacos:
+        enabled: true
+      ribbon:
+        enabled: false
   application:
     name: ts-contacts-service
   datasource:

--- a/ts-inside-payment-service/src/main/java/inside_payment/service/InsidePaymentService.java
+++ b/ts-inside-payment-service/src/main/java/inside_payment/service/InsidePaymentService.java
@@ -14,7 +14,7 @@ public class InsidePaymentService {
         System.out.println("[TrainTicket][InsidePayment] Processing drawback for order: " + orderId);
         System.out.println("[TrainTicket][InsidePayment] User: " + userId + ", Amount: " + money);
         
-        if (featureFlagService.isEnabled("fault-1-async-message-order")) {
+        if (featureFlagService.isEnabled("fault-1-async-message-sequence-control")) {
             System.out.println("[TrainTicket][InsidePayment][F1 MONITORING] F1 fault is active during payment drawback");
             System.out.println("[TrainTicket][InsidePayment][F1 MONITORING] This operation may be delayed by cancel service");
         }

--- a/ts-voucher-service/Dockerfile
+++ b/ts-voucher-service/Dockerfile
@@ -10,6 +10,7 @@ RUN pip install cryptography
 RUN pip install --no-cache-dir -r requirements.txt
 
 ADD ./server.py /app/
-CMD [ "python", "server.py" ]
+ADD ./feature_flag_service.py /app/
+CMD [ "python", "-u", "server.py" ]
 
 EXPOSE 16101

--- a/ts-voucher-service/feature_flag_service.py
+++ b/ts-voucher-service/feature_flag_service.py
@@ -1,0 +1,36 @@
+import os
+from openfeature import api
+from openfeature.contrib.provider.flagd import FlagdProvider
+from openfeature.contrib.provider.flagd.config import ResolverType, CacheType
+
+
+class FeatureFlagService:
+    """Minimal OpenFeature + flagd client (gRPC/RPC).
+
+    Configuration: flagd gRPC at flagd:8013.
+    The provider and client are initialized once per process.
+    """
+
+    def __init__(self) -> None:
+        provider = FlagdProvider(
+            resolver_type=ResolverType.RPC, 
+            host="flagd", 
+            port=8013,
+            cache=CacheType.DISABLED,
+            max_cache_size=0
+        )
+        api.set_provider(provider)
+        self.client = api.get_client("voucher-service")
+
+    def is_enabled(self, flag_name: str) -> bool:
+        try:
+            details = self.client.get_boolean_details(flag_name, False)
+            print(f"[TrainTicket][Voucher][FeatureFlagService] Flag {flag_name}: value={details.value}, reason={getattr(details, 'reason', 'N/A')}")
+
+            if getattr(details, "reason", None) == "ERROR":
+                print(f"[TrainTicket][Voucher][FeatureFlagService] Provider error for flag {flag_name}")
+                return False
+            return bool(details.value)
+        except Exception as e:
+            print(f"[TrainTicket][Voucher][FeatureFlagService] Error getting flag {flag_name}: {e}")
+            return False

--- a/ts-voucher-service/feature_flag_service.py
+++ b/ts-voucher-service/feature_flag_service.py
@@ -5,19 +5,13 @@ from openfeature.contrib.provider.flagd.config import ResolverType, CacheType
 
 
 class FeatureFlagService:
-    """Minimal OpenFeature + flagd client (gRPC/RPC).
-
-    Configuration: flagd gRPC at flagd:8013.
-    The provider and client are initialized once per process.
-    """
-
     def __init__(self) -> None:
         provider = FlagdProvider(
-            resolver_type=ResolverType.RPC, 
-            host="flagd", 
+            resolver_type=ResolverType.RPC,
+            host="flagd",
             port=8013,
             cache=CacheType.DISABLED,
-            max_cache_size=0
+            max_cache_size=0,
         )
         api.set_provider(provider)
         self.client = api.get_client("voucher-service")
@@ -25,12 +19,18 @@ class FeatureFlagService:
     def is_enabled(self, flag_name: str) -> bool:
         try:
             details = self.client.get_boolean_details(flag_name, False)
-            print(f"[TrainTicket][Voucher][FeatureFlagService] Flag {flag_name}: value={details.value}, reason={getattr(details, 'reason', 'N/A')}")
+            print(
+                f"[TrainTicket][Voucher][FeatureFlagService] Flag {flag_name}: value={details.value}, reason={getattr(details, 'reason', 'N/A')}"
+            )
 
             if getattr(details, "reason", None) == "ERROR":
-                print(f"[TrainTicket][Voucher][FeatureFlagService] Provider error for flag {flag_name}")
+                print(
+                    f"[TrainTicket][Voucher][FeatureFlagService] Provider error for flag {flag_name}"
+                )
                 return False
             return bool(details.value)
         except Exception as e:
-            print(f"[TrainTicket][Voucher][FeatureFlagService] Error getting flag {flag_name}: {e}")
+            print(
+                f"[TrainTicket][Voucher][FeatureFlagService] Error getting flag {flag_name}: {e}"
+            )
             return False

--- a/ts-voucher-service/requirements.txt
+++ b/ts-voucher-service/requirements.txt
@@ -1,3 +1,10 @@
-cryptography
+openfeature-sdk
+openfeature-provider-flagd==0.2.6
+
 tornado
 pymysql
+PyYAML
+cryptography
+protobuf==5.29.0
+grpcio==1.71.2
+typing_extensions

--- a/ts-voucher-service/server.py
+++ b/ts-voucher-service/server.py
@@ -19,6 +19,7 @@ class GetVoucherHandler(tornado.web.RequestHandler):
         orderId = data["orderId"]
         type = data["type"]
 
+        #################################### Fault Injection Code Start ####################################
         # F-17: Too many nested selects -> simulate slow DB by sleeping in MySQL
         try:
             rf17_flag = feature_flag_service.is_enabled("fault-17-nested-sql-select-clause-error")
@@ -29,7 +30,9 @@ class GetVoucherHandler(tornado.web.RequestHandler):
         if rf17_flag:
             print("[TrainTicket][Voucher][F17 ON] Simulating nested SELECT delay (sleeping in DB)...")
             self._simulate_nested_select_delay()
+        #################################### Fault Injection Code End ####################################
 
+        
         #Query for the existence of a corresponding credential based on the order id
         queryVoucher = self.fetchVoucherByOrderId(orderId)
 
@@ -58,7 +61,6 @@ class GetVoucherHandler(tornado.web.RequestHandler):
             self.write(queryVoucher)
 
     def _simulate_nested_select_delay(self):
-        """Simulate F-17: slow DB caused by deeply nested SELECTs via MySQL sleep."""
         try:
             global mysql_config
             conn = pymysql.connect(**mysql_config)

--- a/ts-voucher-service/server.py
+++ b/ts-voucher-service/server.py
@@ -6,8 +6,10 @@ import os
 import pymysql
 import urllib
 import urllib.request
+from feature_flag_service import FeatureFlagService
 
 mysql_config = {}
+feature_flag_service = FeatureFlagService()
 
 class GetVoucherHandler(tornado.web.RequestHandler):
 
@@ -16,6 +18,18 @@ class GetVoucherHandler(tornado.web.RequestHandler):
         data = json.loads(self.request.body)
         orderId = data["orderId"]
         type = data["type"]
+
+        # F-17: Too many nested selects -> simulate slow DB by sleeping in MySQL
+        try:
+            rf17_flag = feature_flag_service.is_enabled("fault-17-nested-sql-select-clause-error")
+        except Exception as e:
+            rf17_flag = False
+            print(f"[TrainTicket][Voucher][F17] Feature flag check failed: {e}")
+        
+        if rf17_flag:
+            print("[TrainTicket][Voucher][F17 ON] Simulating nested SELECT delay (sleeping in DB)...")
+            self._simulate_nested_select_delay()
+
         #Query for the existence of a corresponding credential based on the order id
         queryVoucher = self.fetchVoucherByOrderId(orderId)
 
@@ -42,6 +56,23 @@ class GetVoucherHandler(tornado.web.RequestHandler):
             self.write(self.fetchVoucherByOrderId(orderId))
         else:
             self.write(queryVoucher)
+
+    def _simulate_nested_select_delay(self):
+        """Simulate F-17: slow DB caused by deeply nested SELECTs via MySQL sleep."""
+        try:
+            global mysql_config
+            conn = pymysql.connect(**mysql_config)
+            cur = conn.cursor()
+            # Use built-in MySQL sleep to simulate heavy nested query cost
+            cur.execute("SELECT SLEEP(10);")
+            conn.commit()
+        except Exception as e:
+            print(f"[TrainTicket][Voucher][F17] Error during simulated delay: {e}")
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
     def queryOrderByIdAndType(self,orderId,type):
         # Because nacos-sdk-python does not support nacos 2.x yet, we still use environment variables

--- a/values.yaml
+++ b/values.yaml
@@ -2,6 +2,6 @@ namespace: train-ticket
 job:
   # image: jacksonarthurclark/train-ticket-deploy:latest
   image: saad1038/train-ticket-deploy:latest
-  # TODO: change to IfNotPresent after fault implentations are done
+  # TODO: change to IfNotPresent after fault implementations are done
   # imagePullPolicy: IfNotPresent
   imagePullPolicy: Always

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,5 @@
 namespace: train-ticket
 job:
-  image: jacksonarthurclark/train-ticket-deploy:latest
+  # image: jacksonarthurclark/train-ticket-deploy:latest
+  image: saad1038/train-ticket-deploy:latest
   imagePullPolicy: IfNotPresent

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 namespace: train-ticket
 job:
   # image: jacksonarthurclark/train-ticket-deploy:latest
-  image: saad1038/train-ticket-deploy:0.1.0
+  image: saad1038/train-ticket-deploy:0.2.0
   # TODO: change to IfNotPresent after fault implementations are done
   # imagePullPolicy: IfNotPresent
   imagePullPolicy: Always

--- a/values.yaml
+++ b/values.yaml
@@ -2,4 +2,6 @@ namespace: train-ticket
 job:
   # image: jacksonarthurclark/train-ticket-deploy:latest
   image: saad1038/train-ticket-deploy:latest
-  imagePullPolicy: IfNotPresent
+  # TODO: change to IfNotPresent after fault implentations are done
+  # imagePullPolicy: IfNotPresent
+  imagePullPolicy: Always


### PR DESCRIPTION
### F17 Implementation

#### Fault Description
Fault Description Link: https://fudanselab.github.io/research/MSFaultEmpiricalStudy/fault_replications/F17/fault_description.txt

*Industrial fault description:*
The grid-loading process takes too much time.
Too many nested "select" and "from" clauses are in the constructed SQL statement.

*TrainTicket replicated fault description:*
To simulate the nested select clauses, one procedure of mysql to sleep 10s was created in ts-voucher-service.
Since the front stage has a 5s limit of network request, the query of one order's voucher will be out of time.

#### Fault Implementation
The fault is implemented following the official instructions from the link above. Implemented a 10s sleep in mysql procedure to simulate the nested select clause delay in db. As a result whenever the `/getVoucher` api endpoint is called, the mysql procedure will be called and the request will take >= 10s to complete. For the 5s timeout limit, set the timeout to 5s in the `locustfile.py` file when calling the `/getVoucher` api endpoint.

#### Fault Activation/Deactivation
The fault status is controlled by the flag `fault-17-nested-sql-select-clause-error`.

#### Testing Fault Presence
In the `locustfile.py`, the test flow is as follows:

1. **Login Process**: The test first authenticates with the TrainTicket system using the `_login()` method, which calls `/api/v1/users/login` to obtain a JWT token and user ID.

2. **Order Retrieval**: Before testing the voucher service, the test calls `_get_existing_order_id()` which uses the `ts-order-service` to refresh and get an existing order ID from the user's order history.

3. **Fault Testing**: The `test_fault_17_voucher_slow()` task directly calls the `ts-voucher-service` at `http://ts-voucher-service:16101/getVoucher` with a 5-second timeout. When the fault flag is enabled, the service will sleep for 10 seconds in the database, causing the request to timeout and fail as expected.

4. **Expected Behavior**:
   - **Fault ON**: Request times out after 5s (expected failure)
   - **Fault OFF**: Request completes quickly (<5s) with success

#### Output
##### After Fault Injection
```
[❌] Workload entry at 1755175802.991727 failed with log: {"current_response_time_percentile_50":22,"current_response_time_percentile_95":5000.0,"errors":[{"e...
```

##### After Fault Recovery
```
[✅] Successfully collected 2 workload entries.
```

#### Docker Image Changes
Since the deploy process pulls docker images to deploy the train-ticket app, I had to change the following images to implement the fault:

- `jacksonarthurclark/train-ticket-deploy:latest` --> `saad1038/train-ticket-deploy:latest`
- `codewisdom/ts-voucher-service:0.1.0` --> `saad1038/ts-voucher-service:latest`
