### PR TITLE
Rename train-ticket flags

### DIFF
--- a/templates/flagd-config.yaml
+++ b/templates/flagd-config.yaml
@@ -6,154 +6,154 @@ metadata:
 data:
   flags.yaml: |
     flags:
-      fault-1-async-message-sequence-control:
+      tt-feat-01:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-2-data-request-order-inconsistency:
+
+      tt-feat-02:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-3-jvm-docker-config-mismatch:
+
+      tt-feat-03:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-4-ssl-offloading-granularity:
+
+      tt-feat-04:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-5-high-load-timeout-cascade:
+
+      tt-feat-05:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-6-sql-error-recursive-requests:
+
+      tt-feat-06:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-7-third-party-service-overload:
+
+      tt-feat-07:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-8-request-key-propagation-failure:
+
+      tt-feat-08:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-9-css-bidirectional-display-error:
+
+      tt-feat-09:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-10-bom-api-unexpected-output:
+
+      tt-feat-10:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-11-bom-data-sequence-error:
+
+      tt-feat-11:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-12-price-status-query-chain-error:
+
+      tt-feat-12:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-13-price-optimization-order-error:
+
+      tt-feat-13:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-14-locked-product-cpi-calculation-error:
+
+      tt-feat-14:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-15-spark-actor-system-config-error:
+
+      tt-feat-15:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-16-spray-max-content-length-limit:
+
+      tt-feat-16:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-17-nested-sql-select-clause-error:
+
+      tt-feat-17:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-18-json-chart-data-null-value:
+
+      tt-feat-18:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-19-product-price-french-format-error:
+
+      tt-feat-19:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-20-jboss-db2-jar-classpath-error:
+
+      tt-feat-20:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-21-aria-labeled-accessibility-error:
+
+      tt-feat-21:
         state: ENABLED
         variants:
           "on": true
           "off": false
         defaultVariant: "off"
-      
-      fault-22-sql-column-name-mismatch-error:
+
+      tt-feat-22:
         state: ENABLED
         variants:
           "on": true

--- a/ts-cancel-service/src/main/java/cancel/async/AsyncTask.java
+++ b/ts-cancel-service/src/main/java/cancel/async/AsyncTask.java
@@ -19,7 +19,7 @@ public class AsyncTask {
 
         System.out.println("[TrainTicket][Cancel][AsyncTask] Starting drawback process for order: " + orderId);
 
-        if (featureFlagService.isEnabled("fault-1-async-message-sequence-control")) {
+        if (featureFlagService.isEnabled("tt-feat-01")) {
             Thread.sleep(8000);
         }
 
@@ -39,7 +39,7 @@ public class AsyncTask {
     @Async("mySimpleAsync")
     public Future<Boolean> sendEmail(String email, String orderId) {
 
-        featureFlagService.isEnabled("fault-1-async-message-sequence-control");
+        featureFlagService.isEnabled("tt-feat-01");
 
         System.out.println("[TrainTicket][Cancel][AsyncTask] Sending cancellation email to: " + email);
         System.out.println("[TrainTicket][Cancel][AsyncTask] Order ID: " + orderId);

--- a/ts-cancel-service/src/main/java/cancel/controller/CancelController.java
+++ b/ts-cancel-service/src/main/java/cancel/controller/CancelController.java
@@ -58,7 +58,7 @@ public class CancelController {
     /**
      * Testing endpoint to check feature flag values
      * Usage: GET /api/v1/cancelservice/test/flag/{flagName}
-     * Example: GET /api/v1/cancelservice/test/flag/fault-1-async-message-sequence-control
+     * Example: GET /api/v1/cancelservice/test/flag/tt-feat-01
      */
     @CrossOrigin(origins = "*")
     @GetMapping(path = "/test/flag/{flagName}")

--- a/ts-contacts-service/src/main/java/contacts/service/ContactsServiceImpl.java
+++ b/ts-contacts-service/src/main/java/contacts/service/ContactsServiceImpl.java
@@ -53,7 +53,7 @@ public class ContactsServiceImpl implements ContactsService {
         // FAULT F22: Conditionally execute correct or faulty query based on feature flag
         Contacts contactsTemp = null;
         try {
-            boolean faultEnabled = featureFlagService.isEnabled("fault-22-sql-column-name-mismatch-error");
+            boolean faultEnabled = featureFlagService.isEnabled("tt-feat-22");
             if (faultEnabled) {
                 contactsTemp = contactsRepository.findByAccountIdAndDocumentTypeAndDocumentType(
                     contacts.getAccountId(), contacts.getDocumentNumber(), contacts.getDocumentType());
@@ -80,7 +80,7 @@ public class ContactsServiceImpl implements ContactsService {
             // FAULT F22: Conditionally execute correct or faulty query based on feature flag
         Contacts c = null;
         try {
-            boolean faultEnabled = featureFlagService.isEnabled("fault-22-sql-column-name-mismatch-error");
+            boolean faultEnabled = featureFlagService.isEnabled("tt-feat-22");
 
             if (faultEnabled) {
                 // Execute faulty query - will cause SQL column missing error

--- a/ts-voucher-service/server.py
+++ b/ts-voucher-service/server.py
@@ -22,7 +22,7 @@ class GetVoucherHandler(tornado.web.RequestHandler):
         #################################### Fault Injection Code Start ####################################
         # F-17: Too many nested selects -> simulate slow DB by sleeping in MySQL
         try:
-            rf17_flag = feature_flag_service.is_enabled("fault-17-nested-sql-select-clause-error")
+            rf17_flag = feature_flag_service.is_enabled("tt-feat-17")
         except Exception:
             rf17_flag = False
 


### PR DESCRIPTION
The old flag names like `fault-22-sql-column-name-mismatch-error` leak the root cause directly. If the agent discovers the flag names, it can easily find the root cause and turn off the flag to mitigate the fault, bypassing the actual diagnosis work. This PR renames all 22 flags in the train-ticket `flagd` config to `tt-feat-01` through `tt-feat-22` and updates all references.

Rebuilt and pushed the 3 affected service images (`ts-cancel-service`, `ts-contacts-service`, `ts-voucher-service`) to the registry.
